### PR TITLE
discordbotlist.xyz API added

### DIFF
--- a/blapi.js
+++ b/blapi.js
@@ -204,5 +204,13 @@ const oldListData = {
         "api_shard_id": null,
         "api_shard_count": null,
         "api_shards": null
+    },
+    "discordbotlist.xyz": {
+        "api_docs": null,
+        "api_post": "https://discordbotlist.xyz/api/stats/:id",
+        "api_field": "count",
+        "api_shard_id": null,
+        "api_shard_count": null,
+        "api_shards": null
     }
 };


### PR DESCRIPTION
discordbotlist.xyz just now added an API. I think my edits are correct, might want to double check.
Source: https://i.imgur.com/aM1DARF.png

Can also be added to BotBlock (in theory)