### PR TITLE
Make the post function a promise and ESLint fixes

### DIFF
--- a/blapi.js
+++ b/blapi.js
@@ -46,9 +46,9 @@ const handleInternal = async (client, apiKeys, repeatInterval) => {
       // Checks bot is sharded
       /* eslint-disable camelcase */
       if (client.shard) {
-        if (client.shard.id == 0) {
+        if (client.shard.id === 0) {
           apiKeys.shard_count = client.shard.count;
-          apiKeys.shards = await client.shard.fetchClientValues('guilds.size'); //We assume this works in d.js stable and master, have not tested it yet though
+          apiKeys.shards = await client.shard.fetchClientValues('guilds.size'); // We assume this works in d.js stable and master, have not tested it yet though
           apiKeys.server_count = apiKeys.shards.reduce((prev, val) => prev + val, 0);
         }
       } else {
@@ -90,8 +90,10 @@ module.exports = {
     if (noBotBlockPlis) {
       postToAllLists(guildCount, botID, apiKeys);
     } else {
+      /* eslint-disable camelcase */
       apiKeys.server_count = guildCount;
       apiKeys.bot_id = botID;
+      /* eslint-enable camelcase */
       bttps.post('botblock.org', '/api/count', 'no key needed for this', apiKeys).catch(e => console.error(`BLAPI: ${e}`));
     }
   },
@@ -107,12 +109,14 @@ module.exports = {
    */
   manualPostSharded: (guildCount, botID, apiKeys, shardID, shardCount, shards, noBotBlockPlis) => { // TODO complete
     if (noBotBlockPlis) {
-      postToAllLists(guildCount, botID, apiKeys); //redo function for sharded
-    } else if (shardID == 0) {
+      postToAllLists(guildCount, botID, apiKeys); // redo function for sharded
+    } else if (shardID === 0) {
+      /* eslint-disable camelcase */
       apiKeys.server_count = guildCount;
       apiKeys.bot_id = botID;
       apiKeys.server_count = guildCount;
       apiKeys.shard_count = shardCount;
+      /* eslint-enable camelcase */
       if (shards) {
         apiKeys.shards = shards;
       }

--- a/bttps.js
+++ b/bttps.js
@@ -2,7 +2,7 @@ const https = require('https');
 
 module.exports = {
   // custom made post function
-  post: (domain, apiPath, apiKey, sendObj) => {
+  post: (domain, apiPath, apiKey, sendObj) => new Promise((resolve, reject) => {
     const postData = JSON.stringify(sendObj);
     const options = {
       hostname: domain,
@@ -18,10 +18,12 @@ module.exports = {
     const req = https.request(options, () => { });
     req.on('error', e => {
       console.error(e);
+      reject(e);
     });
     req.write(postData);
     req.end();
-  },
+    resolve();
+  }),
   // custom made get function
   get: url => new Promise((resolve, reject) => {
     https.get(url, resp => {

--- a/package.json
+++ b/package.json
@@ -36,5 +36,5 @@
   "scripts": {
     "lint": "eslint ."
   },
-  "version": "0.4.3"
+  "version": "0.4.4"
 }


### PR DESCRIPTION
There were errors being thrown since the post function wasn't a promise, but `.catch` was being used on it. This fixes that and a few other minor ESLint errors.